### PR TITLE
Change RasterIO.Gdal Package Reference

### DIFF
--- a/Tool-Console/src/Console.csproj
+++ b/Tool-Console/src/Console.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Landis.Core.Implementation" Version="2.0.0" />
     <PackageReference Include="Landis.Landscapes" Version="2.0.0" />
     <PackageReference Include="Landis.RasterIO" Version="2.0.0" />
-    <PackageReference Include="Landis.RasterIO.Gdal" Version="2.0.0" />
+    <PackageReference Include="Landis.RasterIO.Gdal" Version="2.1.0" />
     <PackageReference Include="Landis.SpatialModeling" Version="2.0.0" />
     <PackageReference Include="Landis.Utilities" Version="2.0.0" />
     <PackageReference Include="log4net" Version="2.0.8" />


### PR DESCRIPTION
Updated Core's reference to the Landis.RasterIO.Gdal package to the newest version. This version allows LANDIS-II to run on all Windows x64 architecture.